### PR TITLE
Cleanup header

### DIFF
--- a/site/includes/homepage.css
+++ b/site/includes/homepage.css
@@ -156,7 +156,8 @@ a:visited {
   }
 }
 
-#header ul {
+#headerButtonGroup {
+  display: flex;
   position: relative;
   top: 0px;
   left: 0px;

--- a/site/includes/homepage.css
+++ b/site/includes/homepage.css
@@ -188,7 +188,7 @@ a:visited {
   cursor: pointer;
 }
 
-#header ul li {
+.headerButton {
   font-size: 20pt;
   font-weight: bold;
   display: inline-block;
@@ -196,7 +196,7 @@ a:visited {
   padding: 10px 10px 0px 10px;
 }
 
-#header ul li:hover {
+.headerButton:hover {
   box-shadow: 0px -30px 0px -28px var(--main-accent-color) inset;
   -webkit-box-shadow: 0px -30px 0px -28px var(--main-accent-color) inset;
   -moz-box-shadow: 0px -30px 0px -28px var(--main-accent-color) inset;

--- a/site/includes/homepage.css
+++ b/site/includes/homepage.css
@@ -113,6 +113,7 @@ a:visited {
   text-align: center;
   margin: 4px auto 0px;
   display: flex;
+  height: 50px;
 }
 
 #landingGroup {
@@ -179,9 +180,8 @@ a:visited {
 }
 
 #header h1:hover {
-  box-shadow: 0px -35px 0px -33px var(--main-accent-color) inset;
-  -webkit-box-shadow: 0px -35px 0px -33px var(--main-accent-color) inset;
-  -moz-box-shadow: 0px -35px 0px -33px var(--main-accent-color) inset;
+  height: 51px;
+  border-bottom: var(--main-accent-color) 3px solid;
 }
 
 .headerButton#modulesButton {
@@ -194,12 +194,12 @@ a:visited {
   display: inline-block;
   height: 40px;
   padding: 10px 10px 0px 10px;
+  box-sizing: content-box;
 }
 
-.headerButton:hover {
-  box-shadow: 0px -30px 0px -28px var(--main-accent-color) inset;
-  -webkit-box-shadow: 0px -30px 0px -28px var(--main-accent-color) inset;
-  -moz-box-shadow: 0px -30px 0px -28px var(--main-accent-color) inset;
+.headerButton:hover { 
+  height: 38px;
+  border-bottom: var(--main-accent-color) 3px solid;
 }
 
 #header img {

--- a/site/includes/homepage.css
+++ b/site/includes/homepage.css
@@ -184,11 +184,8 @@ a:visited {
   border-bottom: var(--main-accent-color) 3px solid;
 }
 
-.headerButton#modulesButton {
-  cursor: pointer;
-}
-
 .headerButton {
+  cursor: pointer;
   font-size: 20pt;
   font-weight: bold;
   display: inline-block;
@@ -197,7 +194,7 @@ a:visited {
   box-sizing: content-box;
 }
 
-.headerButton:hover { 
+.headerButton:hover:not(.noHoverIndicator) { 
   height: 38px;
   border-bottom: var(--main-accent-color) 3px solid;
 }

--- a/site/includes/homepage.css
+++ b/site/includes/homepage.css
@@ -8,6 +8,7 @@ CSS for the module browse page
   padding: 0;
   --content-spacer: 5vw;
   --module-cards: 7;
+  --arrow-down-size: 50px;
 }
 
 @media screen and (max-width: 1200px) {
@@ -115,7 +116,7 @@ a:visited {
 }
 
 #landingGroup {
-  height: calc(100vh - 50px);
+  height: calc(100vh - var(--arrow-down-size));
   display: flex;
   flex-flow: column;
   margin: 0px;
@@ -267,6 +268,12 @@ a:visited {
   box-shadow: -29px -1px 29px -25px rgba(0, 0, 0, 0.3) inset;
   -webkit-box-shadow: -29px -1px 29px -25px rgba(0, 0, 0, 0.3) inset;
   -moz-box-shadow: -29px -1px 29px -25px rgba(0, 0, 0, 0.3) inset;
+}
+
+#pageArrowDown {
+  height: var(--arrow-down-size);
+  width: 120%;
+  text-align: center
 }
 
 .pageShadowDown {

--- a/site/includes/homepage.css
+++ b/site/includes/homepage.css
@@ -184,6 +184,10 @@ a:visited {
   -moz-box-shadow: 0px -35px 0px -33px var(--main-accent-color) inset;
 }
 
+.headerButton#modulesButton {
+  cursor: pointer;
+}
+
 #header ul li {
   font-size: 20pt;
   font-weight: bold;

--- a/site/indexNew.php
+++ b/site/indexNew.php
@@ -57,7 +57,7 @@ includes/homepage.js
           <span class="headerButton" id="modulesButton" onclick="switchView('All Modules', $('#allModules')[0], true)">Modules</span>
           <a class="headerButton" href="https://www.gm4.co/wiki" target="_blank">Wiki</a>
           <a class="headerButton" href="https://www.gm4.co/server">Server</a>
-          <span class="headerButton"><div  id="themeButton" onclick="toggleTheme()"></div></span>
+          <span class="headerButton noHoverIndicator" ><div id="themeButton" onclick="toggleTheme()"></div></span>
         </span>
       </div>
     </div>

--- a/site/indexNew.php
+++ b/site/indexNew.php
@@ -53,7 +53,7 @@ includes/homepage.js
             <span>Gamemode 4</span>
           </h1>
         </a>
-        <ul style="display: flex;">
+        <ul id="headerButtonGroup">
           <span style="cursor: pointer;" onclick="switchView('All Modules', $('#allModules')[0], true)"><li>Modules</li></span>
           <a href="https://www.gm4.co/wiki" target="_blank"><li> Wiki</li></a>
           <a href="https://www.gm4.co/server"><li> Server</li></a>

--- a/site/indexNew.php
+++ b/site/indexNew.php
@@ -53,12 +53,12 @@ includes/homepage.js
             <span>Gamemode 4</span>
           </h1>
         </a>
-        <ul id="headerButtonGroup">
-          <span class="headerButton" id="modulesButton" onclick="switchView('All Modules', $('#allModules')[0], true)"><li>Modules</li></span>
-          <a href="https://www.gm4.co/wiki" target="_blank"><li> Wiki</li></a>
-          <a href="https://www.gm4.co/server"><li> Server</li></a>
-          <li><div id="themeButton" onclick="toggleTheme()"></div></li>
-        </ul>
+        <span id="headerButtonGroup">
+          <span class="headerButton" id="modulesButton" onclick="switchView('All Modules', $('#allModules')[0], true)">Modules</span>
+          <a class="headerButton" href="https://www.gm4.co/wiki" target="_blank">Wiki</a>
+          <a class="headerButton" href="https://www.gm4.co/server">Server</a>
+          <span class="headerButton"><div  id="themeButton" onclick="toggleTheme()"></div></span>
+        </span>
       </div>
     </div>
     <div id="slideshowContainer">

--- a/site/indexNew.php
+++ b/site/indexNew.php
@@ -54,7 +54,7 @@ includes/homepage.js
           </h1>
         </a>
         <ul id="headerButtonGroup">
-          <span style="cursor: pointer;" onclick="switchView('All Modules', $('#allModules')[0], true)"><li>Modules</li></span>
+          <span class="headerButton" id="modulesButton" onclick="switchView('All Modules', $('#allModules')[0], true)"><li>Modules</li></span>
           <a href="https://www.gm4.co/wiki" target="_blank"><li> Wiki</li></a>
           <a href="https://www.gm4.co/server"><li> Server</li></a>
           <li><div id="themeButton" onclick="toggleTheme()"></div></li>

--- a/site/indexNew.php
+++ b/site/indexNew.php
@@ -73,7 +73,7 @@ includes/homepage.js
     Lorem ipsum, dolor sit amet consectetur adipisicing elit. Non consequatur sit, quisquam soluta exercitationem hic! Reprehenderit repellendus rem velit blanditiis asperiores est tempora vel, magnam neque enim ipsa, sequi necessitatibus.
   </div>
 </div>
-<div id="pageArrowDown" class="pageShadowDown" style="height: 50px; width: 120%; text-align: center">
+<div id="pageArrowDown" class="pageShadowDown">
   ↓ Scroll down ↓
 </div>
 </div>


### PR DESCRIPTION
The hover indicators of the header buttons are kind of broken since bc7df4a9881140a4edac7161d48d4c1c32cc9276, as `box-sizing: border-box;` was introduced.

This PR addresses this issue and moves the hover indicators back down to the bottom of the header.

This PR also removes the hover indicator for the theme button and adds `cursor: pointer;` for each `.headerButton`.

(This PR is based on #5 => closes #5)