### PR TITLE
Update Site to show 1.19 version of RP

### DIFF
--- a/site/modules/module_sources.json
+++ b/site/modules/module_sources.json
@@ -16,7 +16,8 @@
     "type": "resourcepack",
     "repo": "Gamemode4Dev/GM4_Resources",
     "versions": [
-      { "id": "1.18", "name": "Minecraft Java 1.18", "branch": "master" }
+      { "id": "1.19", "name": "Minecraft Java 1.19", "branch": "master" }
+      { "id": "1.18", "name": "Minecraft Java 1.18", "branch": "ver/1.18" }
     ]
   }
 ]

--- a/site/modules/module_sources.json
+++ b/site/modules/module_sources.json
@@ -16,7 +16,7 @@
     "type": "resourcepack",
     "repo": "Gamemode4Dev/GM4_Resources",
     "versions": [
-      { "id": "1.19", "name": "Minecraft Java 1.19", "branch": "master" }
+      { "id": "1.19", "name": "Minecraft Java 1.19", "branch": "master" },
       { "id": "1.18", "name": "Minecraft Java 1.18", "branch": "ver/1.18" }
     ]
   }


### PR DESCRIPTION
The RP has been updated to support 1.19. This PR should make it visible on the site, however, the site code is black magic, and I may have done it wrong