### PR TITLE
Allow Module Developers to Define Search Keywords

### DIFF
--- a/site/includes/homepage.js
+++ b/site/includes/homepage.js
@@ -83,7 +83,7 @@ function createModuleFilter() {
 	textSearch.placeholder = 'Search...';
 	textSearch.addEventListener('keyup', () => {
 		const filter = textSearch.value.toLowerCase();
-		filterModules('wrongFilter', mod => mod.name.toLowerCase().includes(filter));
+		filterModules('wrongFilter', mod => (mod.name.toLowerCase().includes(filter) || mod.search_keywords.includes(filter)));
 	});
 	moduleFilter.append(textSearch);
 

--- a/site/includes/homepage.js
+++ b/site/includes/homepage.js
@@ -83,7 +83,10 @@ function createModuleFilter() {
 	textSearch.placeholder = 'Search...';
 	textSearch.addEventListener('keyup', () => {
 		const filter = textSearch.value.toLowerCase();
-		filterModules('wrongFilter', mod => (mod.name.toLowerCase().includes(filter) || mod.search_keywords.forEach(kw => kw.toLowerCase()).includes(filter)));
+		filterModules('wrongFilter', mod => (
+			mod.name.toLowerCase().includes(filter)) ||
+			mod.search_keywords?.some(kw => kw.toLowerCase().includes(filter)
+		))
 	});
 	moduleFilter.append(textSearch);
 

--- a/site/includes/homepage.js
+++ b/site/includes/homepage.js
@@ -83,7 +83,7 @@ function createModuleFilter() {
 	textSearch.placeholder = 'Search...';
 	textSearch.addEventListener('keyup', () => {
 		const filter = textSearch.value.toLowerCase();
-		filterModules('wrongFilter', mod => (mod.name.toLowerCase().includes(filter) || mod.search_keywords.includes(filter)));
+		filterModules('wrongFilter', mod => (mod.name.toLowerCase().includes(filter) || mod.search_keywords.forEach(kw => kw.toLowerCase()).includes(filter)));
 	});
 	moduleFilter.append(textSearch);
 


### PR DESCRIPTION
This PR modifies the website's text search under the "All Modules" section to not only search for modules with a matching name, but also compare the search text to a module developer defined list of search keywords (`search_keywords` in `beet.yaml`).

This is helpful to more easily direct people to the right module, e.g. Metallurgy could list "Custom Enchantments" and "Arborenda" in its `search_keywords`.

For this to function properly `search_keywords` may need to be added to our module builder to be accepted as a valid field in the `beet.yaml` under `website`. CC @SpecialBuilder32.

### Disclaimer:
I barely know what I am doing here and could not test this locally. There may be better ways of doing this, or this may not work at all. It would be great if someone with more experience (maybe @misode) could look over this.