### PR TITLE
Fix Tiling of Module Promo Images in Module Preview

### DIFF
--- a/site/includes/module.js
+++ b/site/includes/module.js
@@ -295,7 +295,7 @@ async function createPreview(version, moduleId, onDownload) {
 	const preview = document.createElement('div');
 	preview.classList.add('preview');
 
-	const previewMedia = await createModulePromo(moduleId);
+	const previewMedia = await createFeaturedModulePromo(moduleId);
 	previewMedia.classList.add('previewMedia');
 	preview.append(previewMedia);
 
@@ -345,8 +345,29 @@ function fetchModulePromo(moduleId) {
 }
 
 /**
+ * Creates an element with the first featured module promo image.
+ * @param {string} moduleId  the module id
+ * @returns a promise to a HTMLElement with the loaded promo
+ */
+function createFeaturedModulePromo(moduleId) {
+	return fetchModulePromo(moduleId).then(promo => {
+		const promoFeatures = promo.filter(p => p.featured === true);
+		if (promoFeatures.length === 0) {
+			const promoImages = promo.filter(p => p.type === 'image'); //  there was no featured image, look for the first normal image instead
+			if (promoImages.length === 0) {
+				const img = createModuleIcon(moduleId); // there was no normal image, use module icon instead
+				return img;
+			}
+			return createModulePromoImage(moduleId, promoImages[0]);
+		}
+		return createModulePromoImage(moduleId, promoFeatures[0]);
+	});
+}
+
+/**
  * Create an element with the promo image(s)
  * @param {string} moduleId the module ID
+ * @param {boolean} onlyFeatured whether to only fetch the first featured image instead of all promo art, defaults to false.
  * @returns a promise to a HTMLElement with the loaded promo
  */
 function createModulePromo(moduleId) {

--- a/site/includes/module.js
+++ b/site/includes/module.js
@@ -367,7 +367,6 @@ function createFeaturedModulePromo(moduleId) {
 /**
  * Create an element with the promo image(s)
  * @param {string} moduleId the module ID
- * @param {boolean} onlyFeatured whether to only fetch the first featured image instead of all promo art, defaults to false.
  * @returns a promise to a HTMLElement with the loaded promo
  */
 function createModulePromo(moduleId) {

--- a/site/modules/media/shapeless_portals/site_meta.json
+++ b/site/modules/media/shapeless_portals/site_meta.json
@@ -2,6 +2,7 @@
     "promo_images": [
         {
             "type": "image",
+            "featured": true,
             "image": "setting-up-a-portal.webp",
             "credit": "Thanathor",
             "alt": "Creating an oddly shaped portal."


### PR DESCRIPTION
## Overview
This PR addresses the broken tiling in the module preview section if multiple module images exist.

These were inteded to be shown in a 2 by 2 grid of 4 images exist, or as a single image otherwise. However, due to some malformed `css` and some missing `html` elements, this does not work. Instead the images are stacked in one column, see below.

### Broken Tiling
![Broken Tiling](https://github.com/Gamemode4Dev/gm4.co/assets/41843855/ca3e044a-ea2d-466c-b5d9-232c6db29f4d)

### "Working" Tiling (Single Image)
![image](https://github.com/Gamemode4Dev/gm4.co/assets/41843855/2b06b8c7-a9f4-457a-b7a1-f0e143f7c7fe)

# Solution
Instead of fixing the tiling in the preview section this PR actually removes the tiling code for that part of the website.
After a short talk with @TheThanathor we decided that showing 4 images in the (rather small) preview image container may be quite overwhelming. Instead, the 2 by 2 grid of images (if 4 images are available) is only shown on the module page.
In the preview section only a single image is shown, follwing the logic below:

1. Is there a promo item that is flagged with `"featured": true`?
    ✅Display this promo item!
    ❌Continue below.
2. Is there a promo item with `"type": image`?
    ✅Display the first promo item with `"type": image`.
    ❌Display the module icon.

As with my last two PRs I'd be thankful if someone can look over this, I'm not great at js.
Also, I'm sorry for causing you conflicts @misode ):