### PR TITLE
Evergrowth external links open in a new  tab

### DIFF
--- a/site/evergrowth/index.php
+++ b/site/evergrowth/index.php
@@ -69,7 +69,7 @@
       <img src="/images/message_in_a_bottle.svg">
       Download Resource Pack
     </a>
-    <a href="https://github.com/Gamemode4Dev/evergrowth" target="_BLANK" class="squircleLink viewCodeLink">
+    <a href="https://github.com/Gamemode4Dev/evergrowth" target="_blank" class="squircleLink viewCodeLink">
       <img src="/images/logo/github.svg">
       Report a Bug! (or on Discord!)
     </a>
@@ -77,7 +77,7 @@
   <div class="credits">
     <h2>Credits</h3>
       <div class="credits-list">
-        <a href="https://gm4.co/discord" target="_BLANK">
+        <a href="https://gm4.co/discord" target="_blank">
         <div class="creator">
           <div class="creator-image">
             <img src="https://cravatar.eu/helmavatar/thanathor/16.png"></img>
@@ -88,7 +88,7 @@
         </a>
         </div>
         <div class="creator">
-        <a href="https://linktr.ee/kyrius" target="_BLANK">
+        <a href="https://linktr.ee/kyrius" target="_blank">
           <div class="creator-image">
             <img src="https://cravatar.eu/helmavatar/kyrkis/16.png"></img>
             <h4>Kyrkis</h4>
@@ -100,7 +100,7 @@
       </div>
       <div class="credits-list">
         <div class="creator small">
-          <a href="https://twitter.com/ToffeeMax" target="_BLANK">
+          <a href="https://twitter.com/ToffeeMax" target="_blank">
           <div class="creator-image">
             <img src="https://cravatar.eu/helmavatar/toffeemax/16.png"></img>
             <h4>ToffeeMax</h4>
@@ -124,7 +124,7 @@
           <p>Supplimentary Music</p>
         </div>
         <div class="creator small">
-          <a href="https://linktr.ee/miraku_memo" target="_BLANK">
+          <a href="https://linktr.ee/miraku_memo" target="_blank">
           <div class="creator-image">
             <img src="https://cravatar.eu/helmavatar/miraku_memo/16.png"></img>
             <h4>miraku_memo</h4>

--- a/site/evergrowth/index.php
+++ b/site/evergrowth/index.php
@@ -69,7 +69,7 @@
       <img src="/images/message_in_a_bottle.svg">
       Download Resource Pack
     </a>
-    <a href="https://github.com/Gamemode4Dev/evergrowth" class="squircleLink viewCodeLink">
+    <a href="https://github.com/Gamemode4Dev/evergrowth" target="_BLANK" class="squircleLink viewCodeLink">
       <img src="/images/logo/github.svg">
       Report a Bug! (or on Discord!)
     </a>
@@ -77,7 +77,7 @@
   <div class="credits">
     <h2>Credits</h3>
       <div class="credits-list">
-        <a href="https://gm4.co/discord">
+        <a href="https://gm4.co/discord" target="_BLANK">
         <div class="creator">
           <div class="creator-image">
             <img src="https://cravatar.eu/helmavatar/thanathor/16.png"></img>
@@ -88,7 +88,7 @@
         </a>
         </div>
         <div class="creator">
-        <a href="https://linktr.ee/kyrius">
+        <a href="https://linktr.ee/kyrius" target="_BLANK">
           <div class="creator-image">
             <img src="https://cravatar.eu/helmavatar/kyrkis/16.png"></img>
             <h4>Kyrkis</h4>
@@ -100,7 +100,7 @@
       </div>
       <div class="credits-list">
         <div class="creator small">
-          <a href="https://twitter.com/ToffeeMax">
+          <a href="https://twitter.com/ToffeeMax" target="_BLANK">
           <div class="creator-image">
             <img src="https://cravatar.eu/helmavatar/toffeemax/16.png"></img>
             <h4>ToffeeMax</h4>
@@ -124,7 +124,7 @@
           <p>Supplimentary Music</p>
         </div>
         <div class="creator small">
-          <a href="https://linktr.ee/miraku_memo">
+          <a href="https://linktr.ee/miraku_memo" target="_BLANK">
           <div class="creator-image">
             <img src="https://cravatar.eu/helmavatar/miraku_memo/16.png"></img>
             <h4>miraku_memo</h4>


### PR DESCRIPTION
Credit links and the bug report link will now open in a new tab. This is my preferred behaviour for links to external sites, as it keeps our website open, encouraging them to continue browsing the site afterwards instead of getting distracted by the link and forgetting to come back!