### PR TITLE
Module Cards look nicer while loading

### DIFF
--- a/site/includes/homepage.css
+++ b/site/includes/homepage.css
@@ -313,6 +313,8 @@ CSS for the module browse page
 }
 
 .moduleCard img {
+  background-color:#c1ccd1;
+  font-size:0px;
   border-radius: 10%;
   transition: transform 0.1s;
   height: calc(var(--item-width) * 0.75);


### PR DESCRIPTION
Very simple change. Hide the alt text and added a background colour to the module card images so that they look sensible but blank until the image loads in.

Closes #42 