### PR TITLE
Make menu options on header when on /old-modules/ subpage be inline

### DIFF
--- a/site/includes/header.css
+++ b/site/includes/header.css
@@ -271,6 +271,7 @@ header li > :first-child {
   font-weight: bold;
   padding: 10px;
   cursor: pointer;
+  align-content: center;
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
Fixes #46 by adding an align-items:center to the css

NOTE:
- Only tested by adding items to DevTools on Chrome, as getting the /old-modules/ to work locally has had problems