### PR TITLE
Only show releases tags and update mc version

### DIFF
--- a/site/evergrowth/evergrowth.js
+++ b/site/evergrowth/evergrowth.js
@@ -15,7 +15,11 @@ function resizeVideo() {
 }
 
 async function fetchLastRelease() {
-	const response = await cachedFetch("https://api.github.com/repos/Gamemode4Dev/evergrowth/releases");
+	const response = await fetch("https://api.github.com/repos/Gamemode4Dev/evergrowth/releases");
 	const data = await response.json();
-	return data[0].tag_name
+	console.log(data)
+	const filteredData = data.filter(release => !release.prerelease);
+	console.log(filteredData);
+	return filteredData[0].tag_name;
+	//return data[0].tag_name
 }

--- a/site/evergrowth/evergrowth.js
+++ b/site/evergrowth/evergrowth.js
@@ -15,11 +15,9 @@ function resizeVideo() {
 }
 
 async function fetchLastRelease() {
-	const response = await fetch("https://api.github.com/repos/Gamemode4Dev/evergrowth/releases");
+	const response = await cachedFetch("https://api.github.com/repos/Gamemode4Dev/evergrowth/releases");
 	const data = await response.json();
-	console.log(data)
 	const filteredData = data.filter(release => !release.prerelease);
-	console.log(filteredData);
 	return filteredData[0].tag_name;
-	//return data[0].tag_name
+
 }

--- a/site/evergrowth/index.php
+++ b/site/evergrowth/index.php
@@ -62,7 +62,7 @@
     </div>
   </div>
   <div class="buttonGrid downloads">
-    <p class="worldVersionInfo">For Minecraft: Java Edition 1.20.2 to 1.21.1</p>
+    <p class="worldVersionInfo">For Minecraft: Java Edition 1.20.2 to 1.21.3</p>
     <a href="https://github.com/Gamemode4Dev/evergrowth/releases/latest/download/Evergrowth.zip" class="squircleLink worldDownloadLink">
       <img src="/images/filled_map.svg">
       <span>Download the Map</span>


### PR DESCRIPTION
- Javascript to only show tag of release if not marked as a pre-release
- Minecraft version to reflect Minecraft Java 1.21.3