### PR TITLE
Replace https://gm4.co/discord and https://gm4.co/wiki with real URLs

### DIFF
--- a/site/evergrowth/index.php
+++ b/site/evergrowth/index.php
@@ -71,7 +71,7 @@
       <img src="/images/message_in_a_bottle.svg">
       Download Latest Resource Pack
     </a>
-    <a href="https://gm4.co/discord" target="_blank" class="squircleLink viewCodeLink">
+    <a href="https://discord.gg/eN257Mr" target="_blank" class="squircleLink viewCodeLink">
       <img src="/images/logo/discord.svg">
       Get Help on Discord
     </a>

--- a/site/includes/footer.php
+++ b/site/includes/footer.php
@@ -1,7 +1,7 @@
 <footer>
   <p>
     Copyright &copy; <?php echo(date('Y')); ?> Gamemode 4<br>
-    <a href="https://gm4.co/discord" target="_blank" rel="noopener">Discord</a> | <a href="https://github.com/Gamemode4Dev/GM4_Datapacks" target="_blank" rel="noopener">Github</a> | <a href="https://twitter.com/GM4Official" target="_blank" rel="noopener">Twitter</a> | <a href="https://www.patreon.com/gamemode4" target="_blank" rel="noopener">Patreon</a>
+    <a href="https://discord.gg/eN257Mr" target="_blank" rel="noopener">Discord</a> | <a href="https://github.com/Gamemode4Dev/GM4_Datapacks" target="_blank" rel="noopener">Github</a> | <a href="https://twitter.com/GM4Official" target="_blank" rel="noopener">Twitter</a> | <a href="https://www.patreon.com/gamemode4" target="_blank" rel="noopener">Patreon</a>
   </p>
   <p class="footer-small">
     Gamemode 4 is not an official Minecraft product, and is not approved by or associated with Mojang Studios. "Minecraft" is a trademark of Mojang AB and any usage of the Minecraft brand on this site is used in accordance with Mojang Studios' <a href="https://account.mojang.com/terms?ref=ft#brand" target="_blank" rel="noopener">Brand and Asset Guidelines</a>.

--- a/site/includes/header.php
+++ b/site/includes/header.php
@@ -8,7 +8,7 @@
   <nav>
     <ul>
       <li>
-        <a href="/wiki" target="_blank" rel="noreferrer"><h1>Wiki</h1></a>
+        <a href="https://wiki.gm4.co/" target="_blank" rel="noreferrer"><h1>Wiki</h1></a>
       </li>
       <li>
         <a href="/team"><h1>Team</h1></a>

--- a/site/index.php
+++ b/site/index.php
@@ -58,7 +58,7 @@ gtag('config', 'UA-63061711-1');
   </div>
   <div class="landingLinks">
     <h2>Join our community</h2>
-    <a class="discordLink squircleLink" href="https://gm4.co/discord" target="_blank" rel="noopener">
+    <a class="discordLink squircleLink" href="https://discord.gg/eN257Mr" target="_blank" rel="noopener">
       <img src="/images/logo/discord.svg" width="31" height="24" alt="Discord Logo">Discord
     </a>
     <a class="githubLink squircleLink" href="https://github.com/Gamemode4Dev/GM4_Datapacks" target="_blank" rel="noopener">

--- a/site/server.php
+++ b/site/server.php
@@ -60,7 +60,7 @@ gtag('config', 'UA-63061711-1', {cookie_flags:'SameSite=None;Secure'});
 			<li>80+ GM4 Datapacks adding a range of custom items, blocks and features</li>
 			<li>Special Items and machines that change the way you can play or farm</li>
 		</ul>
-    	<p>To keep up to date with all the latest news, <a href='https://gm4.co/discord'>join our Discord Server!</a></p>
+		<p>To keep up to date with all the latest news, <a href='https://discord.gg/eN257Mr'>join our Discord Server!</a></p>
 		<p>Looking for the world downloads of our past seasons? <a href="https://gm4.co/downloads">Check out our downloads page!</a></p>
 		<br />
 


### PR DESCRIPTION
This ensures that users can always access the real URLs even if the webserver is down or misbehaving and it is consistent with our links to other sites like GitHub and Patreon.

While this means we have to replace the URL in a few different files if we ever start using a new Discord invite link, it's very easy to search and replace every instance in every file, and it's nice to have less redirects and dependency on external components (why make a new request that depends on our webserver configuration for an off-site URL when we could directly link the user?).

(I also fixed the indentation for the Discord link in site/server.php)